### PR TITLE
Upgrade to NixOS 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,16 +144,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1763992789,
-        "narHash": "sha256-WHkdBlw6oyxXIra/vQPYLtqY+3G8dUVZM8bEXk0t8x4=",
+        "lastModified": 1764536451,
+        "narHash": "sha256-BgtcUkBfItu9/yU14IgUaj4rYOanTOUZjUfBP20/ZB4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44831a7eaba4360fb81f2acc5ea6de5fde90aaa3",
+        "rev": "3fdd076e08049a9c7a83149b270440d9787d2df5",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -199,16 +199,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1762912391,
-        "narHash": "sha256-4hpBE7bGd24SfD28rzMdUGXsLsNEYxCCrTipFdoqoNM=",
+        "lastModified": 1764161084,
+        "narHash": "sha256-HN84sByg9FhJnojkGGDSrcjcbeioFWoNXfuyYfJ1kBE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "d76299b2cd01837c4c271a7b5186e3d5d8ebd126",
+        "rev": "e95de00a471d07435e0527ff4db092c84998698e",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
-        "ref": "nix-darwin-25.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -235,16 +234,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764316264,
-        "narHash": "sha256-82L+EJU+40+FIdeG4gmUlOF1jeSwlf2AwMarrpdHF6o=",
+        "lastModified": 1764494334,
+        "narHash": "sha256-x2xCEXUlU4Ap56+t5HaoReOQ/bV/bIQ5rzTn/m+V3HQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9a7b80b6f82a71ea04270d7ba11b48855681c4b0",
+        "rev": "d542db745310b6929708d9abea513f3ff19b1341",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -326,11 +325,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764445028,
-        "narHash": "sha256-ik6H/0Zl+qHYDKTXFPpzuVHSZE+uvVz2XQuQd1IVXzo=",
+        "lastModified": 1764527385,
+        "narHash": "sha256-nA5ywiGKl76atrbdZ5Aucd8SjF/v8ew9b9QsC+MKL14=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a09378c0108815dbf3961a0e085936f4146ec415",
+        "rev": "23258e03aaa49b3a68597e3e50eb0cbce7e42e9d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     # Flake framework
@@ -11,12 +11,14 @@
 
     # Home manager
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.05";
+      url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # NOTE: nix-darwin-25.11 doesn't exist yet (see https://github.com/LnL7/nix-darwin/issues/1647)
+    # Using master until the branch is created
     nix-darwin = {
-      url = "github:LnL7/nix-darwin/nix-darwin-25.05";
+      url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/modules/home/cli.nix
+++ b/modules/home/cli.nix
@@ -25,7 +25,7 @@ in
       btop
       dig
       dogdns
-      du-dust
+      dust
       duf
       envsubst
       unstable.eza

--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -18,10 +18,12 @@ in
     programs.ghostty = {
       enable = true;
 
-      # Set to null on Darwin since ghostty package is marked as broken
-      # You can install Ghostty separately (e.g., from the app or building manually)
+      # Set to null since we install Ghostty separately (e.g., from the app or Homebrew)
       # This module will still manage your config at $XDG_CONFIG_HOME/ghostty/config
       package = null;
+
+      # Disable systemd integration (requires package to be set)
+      systemd.enable = false;
 
       # Enable shell integrations for better terminal experience
       enableBashIntegration = true;

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -19,29 +19,29 @@ in
     programs.git = {
       enable = true;
       package = pkgs.git;
-      aliases = {
-        a = "add";
-        snapshot = ''!git stash save "snapshot: $(date)" && git stash apply "stash@{0}"'';
-        snapshots = "!git stash list --grep snapshot";
-        b = "branch -v";
-        c = "commit --signoff -m";
-        ca = "commit --signoff -am";
-        ci = "commit --signoff";
-        commit = "commit --signoff";
-        co = "checkout";
-        d = "diff";
-        l = "log --graph --date=short";
-        nb = "checkout -b";
-        r = "remote -v";
-        uncommit = "reset --soft HEAD^";
-        s = "status";
-        t = "tag -n";
-      };
       signing = {
         format = "ssh";
         signByDefault = true;
       };
-      extraConfig = {
+      settings = {
+        alias = {
+          a = "add";
+          snapshot = ''!git stash save "snapshot: $(date)" && git stash apply "stash@{0}"'';
+          snapshots = "!git stash list --grep snapshot";
+          b = "branch -v";
+          c = "commit --signoff -m";
+          ca = "commit --signoff -am";
+          ci = "commit --signoff";
+          commit = "commit --signoff";
+          co = "checkout";
+          d = "diff";
+          l = "log --graph --date=short";
+          nb = "checkout -b";
+          r = "remote -v";
+          uncommit = "reset --soft HEAD^";
+          s = "status";
+          t = "tag -n";
+        };
         apply.whitespace = "nowarm";
         branch.autosetupmerge = true;
         color.ui = true;

--- a/modules/home/kubernetes.nix
+++ b/modules/home/kubernetes.nix
@@ -44,7 +44,7 @@ in
     # k9s configuration
     programs.k9s = {
       enable = true;
-      plugin = {
+      plugins = {
         plugins = {
           # https://github.com/derailed/k9s/blob/master/plugins/debug-container.yaml
           debug = {

--- a/modules/home/ssh.nix
+++ b/modules/home/ssh.nix
@@ -17,7 +17,12 @@ in
   config = lib.mkIf cfg.enable {
     programs.ssh = {
       enable = true;
+      # Disable deprecated default config - we set our own defaults in matchBlocks."*"
+      enableDefaultConfig = false;
       # add custom settings to config
+      matchBlocks."*" = {
+        addKeysToAgent = "yes";
+      };
       matchBlocks."cloud" = {
         hostname = "cloud.eviljungle.com";
         user = "jeff";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,17 +9,17 @@
   # Unstable nixpkgs accessible via 'pkgs.unstable'
   unstable-packages = final: _prev: {
     unstable = import inputs.nixpkgs-unstable {
-      system = final.system;
+      system = final.stdenv.hostPlatform.system;
       config.allowUnfree = true;
     };
   };
 
   # External input overlays
   talhelper-overlay = final: _prev: {
-    inherit (inputs.talhelper.packages.${final.system}) talhelper;
+    inherit (inputs.talhelper.packages.${final.stdenv.hostPlatform.system}) talhelper;
   };
 
   opnix-overlay = final: _prev: {
-    opnix = inputs.opnix.packages.${final.system};
+    opnix = inputs.opnix.packages.${final.stdenv.hostPlatform.system};
   };
 }

--- a/users/jeff/default.nix
+++ b/users/jeff/default.nix
@@ -16,8 +16,10 @@
 
   # Common git configuration for jeff
   programs.git = {
-    userName = lib.mkDefault "billimek";
-    userEmail = lib.mkDefault "jeff@billimek.com";
+    settings.user = {
+      name = lib.mkDefault "billimek";
+      email = lib.mkDefault "jeff@billimek.com";
+    };
     signing = {
       key = lib.mkDefault "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhZTlonLeCLJpBtuSQcqofKoUbr2ajG3JXxZ7Gjdgkh";
       signer = lib.mkDefault "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";

--- a/users/jeff/hosts/work-laptop.nix
+++ b/users/jeff/hosts/work-laptop.nix
@@ -58,12 +58,14 @@ in
   home.file.".ssh/id_ghec.pub".text = secrets.work_git_pubkey;
 
   programs.git = {
-    userName = lib.mkForce "Jeff Billimek";
-    userEmail = lib.mkForce secrets.work_email;
-    signing.key = lib.mkForce secrets.work_git_pubkey;
-    extraConfig = {
+    settings = {
+      user = {
+        name = lib.mkForce "Jeff Billimek";
+        email = lib.mkForce secrets.work_email;
+      };
       core.sshCommand = "ssh -i ~/.ssh/id_ghec.pub -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
     };
+    signing.key = lib.mkForce secrets.work_git_pubkey;
     includes = [
       {
         condition = "gitdir:~/src.github/";

--- a/users/nix/default.nix
+++ b/users/nix/default.nix
@@ -16,12 +16,10 @@
 
   # Common git configuration for nix user
   programs.git = {
-    userName = lib.mkDefault "billimek";
-    userEmail = lib.mkDefault "jeff@billimek.com";
-    extraConfig = {
-      user = {
-        signingKey = lib.mkDefault "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhZTlonLeCLJpBtuSQcqofKoUbr2ajG3JXxZ7Gjdgkh";
-      };
+    settings.user = {
+      name = lib.mkDefault "billimek";
+      email = lib.mkDefault "jeff@billimek.com";
+      signingKey = lib.mkDefault "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhZTlonLeCLJpBtuSQcqofKoUbr2ajG3JXxZ7Gjdgkh";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Upgrade nixpkgs from 25.05 to 25.11
- Upgrade home-manager from release-25.05 to release-25.11
- Switch nix-darwin to master branch (25.11 branch pending [nix-darwin#1647](https://github.com/LnL7/nix-darwin/issues/1647))

## Breaking Changes Fixed

- `du-dust` package renamed to `dust`
- `programs.git.aliases` → `programs.git.settings.alias`
- `programs.git.extraConfig` → `programs.git.settings`
- `programs.git.userName/userEmail` → `programs.git.settings.user.name/email`
- `programs.k9s.plugin` → `programs.k9s.plugins`
- `programs.ssh` deprecated defaults - added `enableDefaultConfig = false`
- `programs.ghostty.systemd.enable` - explicitly disabled (requires package)
- `final.system` → `final.stdenv.hostPlatform.system` in overlays

## Test plan

- [x] Darwin build and switch (Jeffs-M3Pro)
- [x] Home Manager switch on Darwin
- [x] NixOS build and switch (home)
- [x] Home Manager switch on Linux (jeff@home)
- [ ] NixOS build and switch (cloud)
- [x] NixOS build and switch (nas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)